### PR TITLE
Symlinking secrets file.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,7 @@ set :deploy_to, '/home/deploy/dare_kickstarter'
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w{config/database.yml}
+set :linked_files, %w{config/database.yml config/secrets.yml}
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}


### PR DESCRIPTION
Symlinking secrets file for Capistrano deployment. Should have done in previous merge request, negligence.

Reviewers: @DarryQueen
